### PR TITLE
Reduce Sphinx Warning/Errors On Build

### DIFF
--- a/docroot/cli_tutorial/command_list/p3-signature-clusters.rst
+++ b/docroot/cli_tutorial/command_list/p3-signature-clusters.rst
@@ -22,8 +22,7 @@ Compute Cluster Signatures
 
 
 The standard input file normally contains \ *[n/a, n/a, family_id, feature_id, contig, start, end, strand, function]*\ 
-(the first two columns are ignored). Such a file is created from a family signatures file (output of
-:ref:`cli::p3-signature-familes`) using the following command
+(the first two columns are ignored). Such a file is created from a family signatures file (output of `p3-signature-familes <http://docs.patric.local/cli_tutorial/command_list/p3-signature-families.html>`__) using the following command
 
 
 .. code-block:: perl

--- a/docroot/cli_tutorial/rasttk_incremental_commands.rst
+++ b/docroot/cli_tutorial/rasttk_incremental_commands.rst
@@ -11,9 +11,9 @@ typed object. We will also show some of the additional scripts that are
 not part of the standard pipeline. As before, these commands will work
 in the IRIS environment or in the RASTtk app.
 
-To start this tututorial we will retrieve the *E. coli* K-12 contig from
-the PATRIC database. To do this type::
-         p3-genome-fasta --contig 511145.12 > E_coli.contig    
+To start this tututorial we will retrieve the *E. coli* K-12 contig from the PATRIC database. To do this type::
+
+    p3-genome-fasta --contig 511145.12 > E_coli.contig    
 
 
 RASTtk Incremental Commands
@@ -81,9 +81,9 @@ individually.
          7.  Calls CRISPRs
          8.  Calls the protein-encoding genes with Prodigal and Glimmer3
          9.  Annotates protein-encoding genes with k-mers (version 2),
-        10.  Annotates remaining hypothetical proteins with k-mers (version 1),
-        11.  Attempts to annotate remaining hypothetical proteins by blasting against close relatives (if possible)
-        12.  Performs a basic gene overlap removal
+         10.  Annotates remaining hypothetical proteins with k-mers (version 1),
+         11.  Attempts to annotate remaining hypothetical proteins by blasting against close relatives (if possible)
+         12.  Performs a basic gene overlap removal
 
 The tools that we list below represent a growing collection that can be
 invoked to alter/enhance the annotations for a genome represented by a
@@ -296,7 +296,7 @@ add to your GTO before exporting, you can use the following::
             aliases  (optional)  Comma-separated list of aliases for this feature
 
 Summary
-=======
+-------
 
 The RASTtk Toolkit being developed at Argonne National Laboratory will
 offer a framework for constructing customized annotation pipelines. This

--- a/docroot/tutorial/dev_at_argonne.rst
+++ b/docroot/tutorial/dev_at_argonne.rst
@@ -154,14 +154,14 @@ following configuration::
      ]
    }
 
-The application specifications may be found in the `app_service repository at
-github <https://github.com/TheSEED/app_service/tree/master/app_specs>`_. 
+The application specifications may be found in the app_service `repository`__ on
+GitHub. 
 
 Each application service is implemented by a program named
 ``App-ApplicationName``. Thus the phylogenetic tree application is
 called ``App-PhylogeneticTree``. Sources for the applications are
-also found in the `app_service repository at
-github <https://github.com/TheSEED/app_service/tree/master/scripts>`_. 
+also found in the app_service `repository`__ on
+GitHub. 
 
 All of the application scripts accept the same parameters, described
 by its usage statement::
@@ -225,3 +225,6 @@ We see the execution beginning here. There is a fairly large amount of
 debugging output from both the application service infrastructure as
 well as the tools invoked by the application service infrastructure to
 accomplish the computation desired.
+
+__ https://github.com/TheSEED/app_service/tree/master/app_specs
+__ https://github.com/TheSEED/app_service/tree/master/scripts

--- a/docroot/tutorial/metagenomic_binning/metagenomic_binning.rst
+++ b/docroot/tutorial/metagenomic_binning/metagenomic_binning.rst
@@ -18,7 +18,7 @@ Basic Steps
 Log in to the PATRIC Website
 ----------------------------
 
-See :ref:`website-login` for information on logging in to the PATRIC website.
+See `website-login <http://docs.patric.local/user_guides/registration.html?highlight=website%20login#login>`__ for information on logging in to the PATRIC website.
 You should see something like this:
 
 .. image:: images/website.png

--- a/docroot/user_guides/index.rst
+++ b/docroot/user_guides/index.rst
@@ -1,4 +1,4 @@
-New User Guides (Working In Progress)
+New User Guides (Work In Progress)
 ======================================
 
 The PATRIC website provides an entry point to integrated data and tools


### PR DESCRIPTION
This PR reduces warnings and errors on building p3_docs. 

Currently, only one warning remains for 'master-index.rst' but it's needed to reduce errors caused by other orphaned docs. 